### PR TITLE
Pull all local images

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 if not sys.version_info[0] == 3:
     sys.exit("Sorry, this is a Python 3 utility")
 
-install_requires = ["docker-py==1.8.1", "progressbar2==3.5.0"]
+install_requires = ["docker==2.0.2", "progressbar2==3.5.0"]
 
 setup(
     author="Grahame Bowland",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     keywords="docker",
     url="https://github.com/grahame/wrfy",
     name="wrfy",
-    version="0.5.0",
+    version="0.6.0",
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     install_requires=install_requires,
     entry_points={

--- a/wrfy/cli.py
+++ b/wrfy/cli.py
@@ -2,7 +2,8 @@ import argparse
 import sys
 import re
 
-from docker import Client
+from docker import APIClient as Client
+from docker.errors import APIError
 from fnmatch import fnmatch
 
 from .image import Image
@@ -31,9 +32,12 @@ def pull_all(args):
         pad = max(len(status_title(t)) for t in tags)
         for tag in sorted(tags):
             log_action("pulling tag: %s" % (tag))
-            print_status_stream(
-                status_title(tag, pad),
-                cli.pull(tag, stream=True))
+            try:
+                print_status_stream(
+                    status_title(tag, pad),
+                    cli.pull(tag, stream=True))
+            except APIError as err:
+                print(err)
 
     cli = Client()
     tags = Image.repotags(cli)


### PR DESCRIPTION
Patch to consume API errors when pulling images. Includes an update to docker-py.

Images that don't exist remotely will log, like so:

```
› wrfy pull-all                          
 - pulling tag: aaaasomerandomimage:latest
404 Client Error: Not Found for url: http+docker://localunixsocket/v1.24/images/create?tag=latest&fromImage=aaaasomerandomimage ("repository aaaasomerandomimage not found: does not exist or no pull access")
```